### PR TITLE
fix: 1.3.0版本选项级联修改后参数后，联动表单数据未获取新数据

### DIFF
--- a/packages/core/src/components/formFields/select/common.tsx
+++ b/packages/core/src/components/formFields/select/common.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { ReactNode } from 'react'
 import EnumerationHelper, { EnumerationOptionsConfig, InterfaceEnumerationOptionsKVConfig, InterfaceEnumerationOptionsListConfig } from '../../../util/enumeration'
 import InterfaceHelper from '../../../util/interface'
@@ -40,7 +41,7 @@ export default class SelectField<C extends SelectFieldConfig, E, T> extends Fiel
       EnumerationHelper.options(
         config,
         (config, source) => this.interfaceHelper.request(config, source, { record: this.props.record, data: this.props.data, step: this.props.step }, { loadDomain: this.props.loadDomain }, this),
-        { record: this.props.record, data: this.props.data, step: this.props.step }
+        { record: this.props.record, data: _.cloneDeep(this.props.data), step: this.props.step }
       ).then((options) => {
         if (JSON.stringify(this.state.options) !== JSON.stringify(options)) {
           this.setState({
@@ -72,7 +73,7 @@ export class SelectDisplay<C extends SelectFieldConfig, E, T> extends Display<C,
     if (config) {
       EnumerationHelper.options(
         config,
-        (config, source) => this.interfaceHelper.request(config, source, { record: this.props.record, data: this.props.data, step: this.props.step }, { loadDomain: this.props.loadDomain }),
+        (config, source) => this.interfaceHelper.request(config, source, { record: this.props.record, data: _.cloneDeep(this.props.data), step: this.props.step }, { loadDomain: this.props.loadDomain }),
         { record: this.props.record, data: this.props.data, step: this.props.step }
       ).then((options) => {
         if (JSON.stringify(this.state.options) !== JSON.stringify(options)) {

--- a/packages/core/src/util/enumeration.ts
+++ b/packages/core/src/util/enumeration.ts
@@ -52,7 +52,7 @@ export default class EnumerationHelper {
     config: EnumerationOptionsConfig,
     interfaceRequire: (config: InterfaceConfig, source: any) => Promise<any>,
     datas: { record?: object, data: object[], step: { [field: string]: any } }
-  ): Promise<{ value: unknown, label: string }[]> {
+  ): Promise<{ value: any, label: string }[]> {
     if (config) {
       if (config.from === 'manual') {
         if (config.data) {


### PR DESCRIPTION
- 1.3.0版本选项级联修改后参数后，联动表单数据未获取新数据
