### PR TITLE
perf: 优化下拉选项配置值为负数时的逻辑判断

### DIFF
--- a/packages/core/src/components/formFields/select/single/display.tsx
+++ b/packages/core/src/components/formFields/select/single/display.tsx
@@ -7,20 +7,19 @@ export interface ISelectSingleField {
   options: Array<ISelectFieldOption>
 }
 
-export default class SelectSingleDisplay extends SelectDisplay<SelectSingleFieldConfig, {}, string | number | boolean | undefined> {
+export default class SelectSingleDisplay extends SelectDisplay<
+  SelectSingleFieldConfig,
+  {},
+  string | number | boolean | undefined
+> {
   renderSelectSingleComponent = (props: ISelectSingleField) => {
-    return <React.Fragment>
-      您当前使用的UI版本没有实现SelectSingleDisplay组件。
-    </React.Fragment>
+    return <>您当前使用的UI版本没有实现SelectSingleDisplay组件。</>
   }
 
   render = () => {
     const {
       value,
-      config: {
-        options: optionsConfig,
-        defaultSelect
-      }
+      config: { options: optionsConfig, defaultSelect }
     } = this.props
 
     const props: ISelectSingleField = {
@@ -40,18 +39,12 @@ export default class SelectSingleDisplay extends SelectDisplay<SelectSingleField
       console.warn('单项选择框的值需要是字符串或数值。')
     } else if (value === undefined) {
       if (defaultSelect !== undefined && defaultSelect !== false && props.options.length) {
-        (async () => {
-          const value = props.options[defaultSelect === true ? 0 : defaultSelect].value
+        ;(async () => {
+          const { value } = props.options[defaultSelect === true || defaultSelect < 0 ? 0 : defaultSelect]
           props.value = value
         })()
       }
     }
-    return (
-      <React.Fragment>
-        {
-          this.renderSelectSingleComponent(props)
-        }
-      </React.Fragment>
-    )
+    return <>{this.renderSelectSingleComponent(props)}</>
   }
 }

--- a/packages/core/src/components/formFields/select/single/index.tsx
+++ b/packages/core/src/components/formFields/select/single/index.tsx
@@ -145,7 +145,7 @@ export default class SelectSingleField<UIState = object> extends SelectField<
     }
     if (currentValue === undefined) {
       if (defaultSelect !== undefined && defaultSelect !== false && props.options.length) {
-        currentValue = props.options[defaultSelect === true ? 0 : defaultSelect]?.value
+        currentValue = props.options[defaultSelect === true || defaultSelect < 0 ? 0 : defaultSelect]?.value
         this.handleChange(currentValue, options)
       }
     } else if (

--- a/packages/editor/src/config/form/select_single.ts
+++ b/packages/editor/src/config/form/select_single.ts
@@ -117,8 +117,9 @@ const config: FieldConfigs[] = [
       },
       {
         field: 'defaultSelect',
-        label: '默认选中项目',
-        type: 'number'
+        label: '默认选中项',
+        type: 'number',
+        min: 0
       }
     ]
   }


### PR DESCRIPTION
感谢您为CCMS项目提交代码，请填写下列信息帮助我们快速完成代码合并工作。

## 修改类型

请将符合本次提交的修改类型前的方括号中替换为`x`。

- [x] 问题修复（修复问题的非破坏性更改）
- [ ] 新特性（添加新功能的非破坏性更改）
- [ ] 破坏性修改（可能会造成现有逻辑无法正常运行的修改）
- [ ] 仅修改文档等非代码逻辑

## 修改内容

请简单表述本次提交代码所修改的内容。
core
1.优化下拉选项配置值为负数时可能出现的错误，补充取值为负数的逻辑
editor
2.添加配置参数为负数的提示

可以输入井号（`#`）已选择关联的议题（Issue）
#26 

## 测试方法

下拉选项配置为 -1 时的报错或者取值错误
