### PR TITLE
refactor: 重构配置文件修改，优化配置文件显示方式，修复配置文件与编辑文件时偶尔不同步的问题

### DIFF
--- a/packages/editor/src/app.tsx
+++ b/packages/editor/src/app.tsx
@@ -162,13 +162,19 @@ class App extends React.Component<AppProps, CCMSConsigState> {
    * 强制刷新
    */
   handleRefreshPreview = () => {
-    this.setState({
-      ready: false
-    }, () => {
-      this.setState({
-        ready: true
-      })
-    })
+    const { activeTab } = this.state
+    this.setState(
+      {
+        activeTab: 0,
+        ready: false
+      },
+      () => {
+        this.setState({
+          ready: true,
+          activeTab
+        })
+      }
+    )
   }
 
   /**
@@ -221,12 +227,7 @@ class App extends React.Component<AppProps, CCMSConsigState> {
   }
 
   render() {
-    const {
-      ready,
-      pageConfig,
-      activeTab,
-      pageTemplate
-    } = this.state
+    const { ready, pageConfig, activeTab, pageTemplate, configStringify } = this.state
 
     const {
       applicationName,
@@ -484,19 +485,15 @@ class App extends React.Component<AppProps, CCMSConsigState> {
         </Drawer>
 
         {/* 编辑配置文件 */}
-        <Modal
-          title="编辑配置文件"
-          visible={this.state.configStringify}
-          footer={false}
+        <ConfigJSON
+          configStringify={configStringify}
+          defaultValue={JSON.stringify(pageConfig, undefined, 2)}
+          onOk={(pageConfig) => {
+            this.setState({ pageConfig, configStringify: false });
+            this.handleRefreshPreview()
+          }}
           onCancel={() => this.setState({ configStringify: false })}
-          getContainer={() => document.getElementById('ccms-config') || document.body}
-        >
-          <ConfigJSON
-            defaultValue={this.state.pageConfig}
-            onOk={(pageConfig) => this.setState({ pageConfig, configStringify: false })}
-            onCancel={() => this.setState({ configStringify: false })}
-          />
-        </Modal>
+        />
       </div>
     )
   }

--- a/packages/editor/src/component/ConfigJSON/index.tsx
+++ b/packages/editor/src/component/ConfigJSON/index.tsx
@@ -1,40 +1,72 @@
-import React, { useEffect } from 'react';
-import { Button, Form, Input, Modal, Space } from "antd";
+import React, { useEffect, useState } from 'react'
+import { Drawer, Button, Modal, Space } from 'antd'
+import Editor, { loader } from '@monaco-editor/react'
+
+loader.config({ paths: { vs: 'https://storage.360buyimg.com/swm-plus/monaco-editor-0.28.1/min/vs' } })
 
 interface ConfigJSONProps {
+  configStringify: boolean
   defaultValue: any
   onOk: (config: any) => void
   onCancel: () => void
 }
 
-export default function ConfigJSON (props: ConfigJSONProps) {
-  const [ form ] = Form.useForm()
+export default function ConfigJSON(props: ConfigJSONProps) {
+  let editorInstance: any = ''
 
   useEffect(() => {
-    form.setFieldsValue({ config: JSON.stringify(props.defaultValue, undefined, 2) })
-  }, [ props.defaultValue ])
+    setConfig(props.defaultValue)
+  }, [props.defaultValue])
+
+  const [config, setConfig] = useState(props.defaultValue)
+
+  const handleEditorDidMount = (editor, monaco) => {
+    editorInstance = editor
+    editorInstance.defaultCodeValue = editor.getValue()
+  }
 
   return (
-    <Form form={form}>
-      <Form.Item name="config" noStyle>
-        <Input.TextArea rows={20}></Input.TextArea>
-      </Form.Item>
-      <Form.Item noStyle>
+    <Drawer
+      width="50%"
+      title="编辑配置文件"
+      placement="right"
+      visible={props.configStringify}
+      getContainer={false}
+      closable
+      maskClosable
+      footer={
         <Space>
-          <Button onClick={() => {
-            const config = form.getFieldValue('config')
-            try {
-              props.onOk(JSON.parse(config))
-            } catch (e: any) {
-              Modal.error({
-                title: '配置文件解析失败',
-                content: e.message
-              })
-            }
-          }} type="primary">确定</Button>
+          <Button
+            onClick={() => {
+              try {
+                props.onOk(JSON.parse(config))
+              } catch (e: any) {
+                Modal.error({
+                  title: '配置文件解析失败',
+                  content: e.message
+                })
+              }
+            }}
+            type="primary"
+          >
+            确定
+          </Button>
           <Button onClick={() => props.onCancel()}>取消</Button>
         </Space>
-      </Form.Item>
-    </Form>
+      }
+      onClose={() => props.onCancel()}
+    >
+      <Editor
+        height={document.body.clientHeight}
+        theme="vs-dark"
+        defaultLanguage="json"
+        language="json"
+        value={config}
+        onMount={handleEditorDidMount}
+        onChange={(v) => {
+          setConfig(v)
+        }}
+      />
+    </Drawer>
   )
 }


### PR DESCRIPTION
感谢您为CCMS项目提交代码，请填写下列信息帮助我们快速完成代码合并工作。

## 修改类型

请将符合本次提交的修改类型前的方括号中替换为`x`。

- [X] 问题修复（修复问题的非破坏性更改）
- [X] 新特性（添加新功能的非破坏性更改）
- [ ] 破坏性修改（可能会造成现有逻辑无法正常运行的修改）
- [ ] 仅修改文档等非代码逻辑

## 修改内容

- 重构配置文件以编辑器方式展示
- 修复查看配置文件编辑后与界面不同步的问题，修复编辑表单后展开配置文件配置文件与编辑JSON不同步的问题
- 优化配置文件查看的样式

可以输入井号（`#`）已选择关联的议题（Issue）

## 测试方法
运行editor查看配置文件
